### PR TITLE
Fix remote image config and login flow bugs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,13 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
     images: {
-        remotePatterns: [new URL('https://i.scdn.co/image/**')],
+        remotePatterns: [
+            {
+                protocol: "https",
+                hostname: "i.scdn.co",
+                pathname: "/image/**",
+            },
+        ],
     },
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
-import {getServerSession, Session} from "next-auth";
+import { getServerSession } from "next-auth";
 import { authOptions } from "./api/auth/[...nextauth]/route";
 import Image from "next/image";
+import { redirect } from "next/navigation";
 
 interface ImageRef {
     url: string;
@@ -28,8 +29,11 @@ async function getTopArtists(accessToken: string): Promise<Artist[]> {
 
 export default async function Home() {
     const session = await getServerSession(authOptions);
+    const accessToken = session?.accessToken;
+    if (!accessToken) {
+        redirect("/login");
+    }
 
-    const accessToken = (session as Session).accessToken as string;
     const [artists] = await Promise.all([
         getTopArtists(accessToken),
     ]);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { NextRequest } from "next/server";
 import { getToken } from "next-auth/jwt";
 
-const PUBLIC_PATHS = ["/login", "/api/auth", "/favicon.ico", "/_next", "/assets"];
+const PUBLIC_PATHS = ["/api/auth", "/favicon.ico", "/_next", "/assets"];
 
 export async function middleware(req: NextRequest) {
     const { pathname } = req.nextUrl;
@@ -14,14 +14,12 @@ export async function middleware(req: NextRequest) {
 
     const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
 
-    // Pas connecté → /login
-    if (!token) {
+    if (!token && pathname !== "/login") {
         const url = req.nextUrl.clone();
         url.pathname = "/login";
         return NextResponse.redirect(url);
     }
 
-    // Connecté et sur /login → racine
     if (token && pathname === "/login") {
         const url = req.nextUrl.clone();
         url.pathname = "/";


### PR DESCRIPTION
## Summary
- fix remote image pattern configuration for Spotify images
- repair middleware login redirects and unauthenticated checks
- guard home page against missing session tokens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689a5fbe27dc83319fd8b0bbf0196bd6