### PR TITLE
feat: play artist top track on click

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Features
+
+- Displays your top Spotify artists.
+- Clicking an artist plays a preview of one of their most listened tracks.
+
 ## Getting Started
 
 First, run the development server:

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,9 @@
 import Link from "next/link";
 import { getServerSession } from "next-auth";
 import { authOptions } from "./api/auth/[...nextauth]/route";
-import Image from "next/image";
 import { redirect } from "next/navigation";
-
-interface ImageRef {
-    url: string;
-    width: number;
-    height: number;
-}
-
-interface Artist {
-    id: string;
-    name: string;
-    images?: ImageRef[];
-}
+import ArtistGrid from "@/components/ArtistGrid";
+import type { Artist } from "@/types/spotify";
 
 // --- API helpers ---
 async function getTopArtists(accessToken: string): Promise<Artist[]> {
@@ -63,27 +52,7 @@ export default async function Home() {
                         </div>
                     </div>
                 ) : (
-                    <ul className="grid grid-cols-1 xs:grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4" aria-label="Liste de vos artistes">
-                        {artists.map((artist) => {
-                            const img = artist.images?.[1]?.url || artist.images?.[0]?.url; // taille moyenne si dispo
-                            return (
-                                <li key={artist.id} className="group">
-                                    <div className="h-full rounded-2xl border border-neutral-200/80 dark:border-neutral-800/80 bg-white/80 dark:bg-neutral-900/50 p-3 transition hover:shadow-sm">
-                                        <div className="aspect-square w-full overflow-hidden rounded-xl bg-neutral-200/60 dark:bg-neutral-800/60">
-                                            {img ? (
-                                                <Image src={img} alt={artist.name} className="h-full w-full object-cover" width={64} height={64} />
-                                            ) : (
-                                                <div className="h-full w-full grid place-items-center text-xs text-neutral-500">Sans image</div>
-                                            )}
-                                        </div>
-                                        <div className="mt-3 space-y-1">
-                                            <p className="text-sm font-medium truncate" title={artist.name}>{artist.name}</p>
-                                        </div>
-                                    </div>
-                                </li>
-                            );
-                        })}
-                    </ul>
+                    <ArtistGrid artists={artists} token={accessToken} />
                 )}
             </main>
 

--- a/src/components/ArtistGrid.tsx
+++ b/src/components/ArtistGrid.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import Image from 'next/image';
+import { useState } from 'react';
+import type { Artist } from '@/types/spotify';
+
+interface Props {
+    artists: Artist[];
+    token: string;
+}
+
+export default function ArtistGrid({ artists, token }: Props) {
+    const [audio, setAudio] = useState<HTMLAudioElement | null>(null);
+
+    async function playArtist(artistId: string) {
+        try {
+            const res = await fetch(`https://api.spotify.com/v1/artists/${artistId}/top-tracks?market=FR`, {
+                headers: { Authorization: `Bearer ${token}` },
+            });
+            if (!res.ok) return;
+            const data: { tracks: { preview_url: string | null }[] } = await res.json();
+            const track = data.tracks?.[0];
+            const preview = track?.preview_url;
+            if (preview) {
+                audio?.pause();
+                const newAudio = new Audio(preview);
+                newAudio.play();
+                setAudio(newAudio);
+            }
+        } catch (err) {
+            console.error('Erreur lors de la lecture de la piste', err);
+        }
+    }
+
+    return (
+        <ul className="grid grid-cols-1 xs:grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4" aria-label="Liste de vos artistes">
+            {artists.map((artist) => {
+                const img = artist.images?.[1]?.url || artist.images?.[0]?.url;
+                return (
+                    <li key={artist.id} className="group">
+                        <button
+                            type="button"
+                            onClick={() => playArtist(artist.id)}
+                            className="h-full w-full text-left rounded-2xl border border-neutral-200/80 dark:border-neutral-800/80 bg-white/80 dark:bg-neutral-900/50 p-3 transition hover:shadow-sm"
+                        >
+                            <div className="aspect-square w-full overflow-hidden rounded-xl bg-neutral-200/60 dark:bg-neutral-800/60">
+                                {img ? (
+                                    <Image src={img} alt={artist.name} className="h-full w-full object-cover" width={64} height={64} />
+                                ) : (
+                                    <div className="h-full w-full grid place-items-center text-xs text-neutral-500">Sans image</div>
+                                )}
+                            </div>
+                            <div className="mt-3 space-y-1">
+                                <p className="text-sm font-medium truncate" title={artist.name}>{artist.name}</p>
+                            </div>
+                        </button>
+                    </li>
+                );
+            })}
+        </ul>
+    );
+}

--- a/src/types/spotify.ts
+++ b/src/types/spotify.ts
@@ -1,0 +1,11 @@
+export interface ImageRef {
+    url: string;
+    width: number;
+    height: number;
+}
+
+export interface Artist {
+    id: string;
+    name: string;
+    images?: ImageRef[];
+}


### PR DESCRIPTION
## Summary
- add client component to play a top track when an artist is clicked
- expose common Spotify types
- document ability to preview tracks

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689a6422f5e48331b7031bb3ca09dd5c